### PR TITLE
Version 1.0.1

### DIFF
--- a/README.md
+++ b/README.md
@@ -21,4 +21,5 @@ Multires Tranpose Version 1.0.0:
         * Use auto iteration to automatically reshape the mesh until the changes are within a specified threshold, or until the specified number of iterations have been reached
 
 ### Known Limitations
+Facesets may not be preserved when creating the transpose target
 Does not work with multiuser data (instancing)

--- a/README.md
+++ b/README.md
@@ -21,5 +21,4 @@ Multires Tranpose Version 1.0.0:
         * Use auto iteration to automatically reshape the mesh until the changes are within a specified threshold, or until the specified number of iterations have been reached
 
 ### Known Limitations
-Facesets are not preserved when creating the transpose target
 Does not work with multiuser data (instancing)

--- a/multires_transpose.py
+++ b/multires_transpose.py
@@ -60,7 +60,7 @@ class MULTIRES_TRANSPOSE_OT_create_transpose_target(LoggerOperator):
         context.view_layer.objects.active = transpose_target
         transpose_target.select_set(True)
 
-        self.logger.info(f"Time taken to create Transpose Target: {time.time() - start_time}")
+        self.logger.debug(f"Time taken to create Transpose Target: {time.time() - start_time}")
         return {"FINISHED"}
 
     def draw(self, context):

--- a/multires_transpose.py
+++ b/multires_transpose.py
@@ -16,16 +16,33 @@ class LoggerOperator(bpy.types.Operator):
     def __init__(self):
         self.logger = logging.getLogger(__name__ + "." + self.__class__.__name__)
 
-# TODO: Add apply base option for when multires level is 0
+
 class MULTIRES_TRANSPOSE_OT_create_transpose_target(LoggerOperator):
     bl_idname = "multires_transpose.create_transpose_target"
     bl_label = "Create Transpose Target"
     bl_options = {'REGISTER', 'UNDO'}
 
-    multires_level: bpy.props.IntProperty(name="Multires Level", default=1, min=0)
-    use_multires_level_as_is: bpy.props.BoolProperty(name="Use Multires Level As Is", default=False)
-    include_non_multires: bpy.props.BoolProperty(name="Include Non-Multires Objects", default=False)
-    hide_original: bpy.props.BoolProperty(name="Hide Original Objects", default=True)
+    multires_level: bpy.props.IntProperty(
+        name="Multires Level",
+        default=1,
+        min=0,
+        description="Multires subdivision level to use when creating the transpose target. Only used if 'Use Multires Level As Is' is disabled"
+    )
+    use_multires_level_as_is: bpy.props.BoolProperty(
+        name="Use Multires Level As Is",
+        default=False,
+        description="Use the current multires level of the selected objects for the transpose target"
+    )
+    include_non_multires: bpy.props.BoolProperty(
+        name="Include Non-Multires Objects",
+        default=False,
+        description="Include objects that do not have a multires modifier in the transpose target"
+    )
+    hide_original: bpy.props.BoolProperty(
+        name="Hide Original Objects",
+        default=True,
+        description="Hide the original objects after creating the transpose target"
+    )
 
     def execute(self, context):
         start_time = time.time()
@@ -69,11 +86,30 @@ class MULTIRES_TRANSPOSE_OT_apply_transpose_target(LoggerOperator):
     bl_label = "Apply Transpose Target"
     bl_options = {'REGISTER', 'UNDO'}
 
-    threshold: bpy.props.FloatProperty(name="Threshold", default=0.01, min=0.0, step=0.01)
-    auto_iterations: bpy.props.BoolProperty(name="Auto Iterations", default=True)
+    threshold: bpy.props.FloatProperty(
+        name="Threshold",
+        default=0.01,
+        min=0.0,
+        step=0.01,
+        description="Threshold for the difference between the original mesh and the transpose target mesh. Only used if Auto Iterations is enabled"
+    )
+    auto_iterations: bpy.props.BoolProperty(
+        name="Auto Iterations",
+        default=True,
+        description="Automatically apply reshape until the threshold is reached."
+    )
     max_auto_iterations: bpy.props.IntProperty(name="Max Auto Iterations", default=100, min=1)
-    iterations: bpy.props.IntProperty(name="Max Iterations", default=5, min=1)
-    hide_transpose: bpy.props.BoolProperty(name="Hide Transpose Target", default=False)
+    iterations: bpy.props.IntProperty(
+        name="Max Iterations",
+        default=1,
+        min=1,
+        description="Maximum number of iterations to apply reshape. Only used if Auto Iterations is disabled"
+    )
+    hide_transpose: bpy.props.BoolProperty(
+        name="Hide Transpose Target",
+        default=False,
+        description="Hide the transpose target after applying it"
+    )
 
     def execute(self, context):
         start_time = time.time()
@@ -85,8 +121,6 @@ class MULTIRES_TRANSPOSE_OT_apply_transpose_target(LoggerOperator):
         # Create individual mesh objects as targets for the multires modifier's reshape operation
         transpose_targets = create_meshes_by_original_name(active_obj)
         self.logger.debug(f"Created {len(transpose_targets)} transpose targets")
-
-        original_objects = []
 
         for object in transpose_targets:
             # Parse the original object name from the transpose target name
@@ -100,8 +134,7 @@ class MULTIRES_TRANSPOSE_OT_apply_transpose_target(LoggerOperator):
             # Make sure that it shows in the depsgraph
             original_obj.hide_set(False)
 
-            original_objects.append(original_obj)
-            with bmesh_from_obj(object) as bm:
+            with bmesh_from_obj(object, write_back=False) as bm:
                 # A mesh after being split is not guaranteed to have the same vertex indices as the original mesh
                 restore_vertex_index(bm)
                 # Apply the inverse transformation of the original object because the original transformation
@@ -168,7 +201,7 @@ class MULTIRES_TRANSPOSE_OT_apply_transpose_target(LoggerOperator):
         col = layout.column()
         col.label(text="Settings:", icon="SETTINGS")
 
-        col.prop(self, "auto_iterations", text="Auto Iterations")
+        col.prop(self, "auto_iterations", text="Auto Iterations. This may take a long time to finish")
         col.prop(self, "hide_transpose", text="Hide Transpose Target")
 
         if self.auto_iterations:

--- a/multires_transpose.py
+++ b/multires_transpose.py
@@ -98,7 +98,12 @@ class MULTIRES_TRANSPOSE_OT_apply_transpose_target(LoggerOperator):
         default=False,
         description="Automatically apply reshape until the threshold is reached."
     )
-    max_auto_iterations: bpy.props.IntProperty(name="Max Auto Iterations", default=100, min=1)
+    max_auto_iterations: bpy.props.IntProperty(
+        name="Max Auto Iterations",
+        default=100,
+        min=1,
+        description="Maximum number of iterations to apply reshape when Auto Iterations is enabled"
+    )
     iterations: bpy.props.IntProperty(
         name="Max Iterations",
         default=1,

--- a/multires_transpose.py
+++ b/multires_transpose.py
@@ -60,7 +60,7 @@ class MULTIRES_TRANSPOSE_OT_create_transpose_target(LoggerOperator):
         context.view_layer.objects.active = transpose_target
         transpose_target.select_set(True)
 
-        self.logger.debug(f"Time taken to create Transpose Target: {time.time() - start_time}")
+        self.logger.info(f"Time taken to create Transpose Target: {time.time() - start_time}")
         return {"FINISHED"}
 
     def draw(self, context):
@@ -95,7 +95,7 @@ class MULTIRES_TRANSPOSE_OT_apply_transpose_target(LoggerOperator):
     )
     auto_iterations: bpy.props.BoolProperty(
         name="Auto Iterations",
-        default=True,
+        default=False,
         description="Automatically apply reshape until the threshold is reached."
     )
     max_auto_iterations: bpy.props.IntProperty(name="Max Auto Iterations", default=100, min=1)

--- a/multires_transpose.py
+++ b/multires_transpose.py
@@ -91,8 +91,7 @@ class MULTIRES_TRANSPOSE_OT_apply_transpose_target(LoggerOperator):
         for object in transpose_targets:
             # Parse the original object name from the transpose target name
             original_obj_name = ""
-            with bmesh_from_obj(object) as bm:
-                original_obj_name = object.name[:-len("_Target")]
+            original_obj_name = object.name[:-len("_Target")]
             if original_obj_name not in bpy.data.objects:
                 self.logger.warn(f"Object {object.name} does not have original object name recorded, skipping")
                 continue
@@ -109,7 +108,7 @@ class MULTIRES_TRANSPOSE_OT_apply_transpose_target(LoggerOperator):
                 # was applied when the transpose target was created
                 bmesh.ops.transform(bm, verts=bm.verts, matrix=original_obj.matrix_world.inverted())
                 # Read the original multires level used to create this transpose target
-                original_multires_level = read_layer_data(bm, MeshDomain.FACES, MeshLayerType.INT, ORIGINAL_SUBDIVISION_LEVEL_LAYER, uniform=True)
+                original_multires_level = read_layer_data(bm, MeshDomain.VERTS, MeshLayerType.INT, ORIGINAL_SUBDIVISION_LEVEL_LAYER, uniform=True)
 
                 # Use the reshape operator to apply the transpose target if the original multires level is greater than 0
                 if original_multires_level > 0:
@@ -125,7 +124,6 @@ class MULTIRES_TRANSPOSE_OT_apply_transpose_target(LoggerOperator):
 
                         # Set the multires level to the original multires level used to create the transpose target
                         multires_modifier.levels = original_multires_level
-
                         if not self.auto_iterations:
                             for _ in range(self.iterations):
                                 bpy.ops.object.multires_reshape(modifier=multires_modifier.name)

--- a/utils/bmesh_context.py
+++ b/utils/bmesh_context.py
@@ -3,10 +3,11 @@ import contextlib
 
 
 @contextlib.contextmanager
-def bmesh_from_obj(obj):
+def bmesh_from_obj(obj, write_back=True):
     mesh_data = obj.data
     bm = bmesh.new()
     bm.from_mesh(mesh_data)
     yield bm
-    bm.to_mesh(mesh_data)
+    if write_back:
+        bm.to_mesh(mesh_data)
     bm.free()

--- a/utils/bmesh_utils.py
+++ b/utils/bmesh_utils.py
@@ -181,20 +181,23 @@ def bmesh_join(list_of_bmeshes: Iterable[bmesh.types.BMesh], normal_update=False
     copy_all_layers(list_of_bmeshes[0], bm)
 
     for bm_to_add in list_of_bmeshes:
-        offset = len(bm.verts)
 
         for v in bm_to_add.verts:
             nv = add_vert(v.co, v)
             nv.copy_from(v)
 
-        bm.verts.index_update()
-        bm.verts.ensure_lookup_table()
+    bm.verts.index_update()
+    bm.verts.ensure_lookup_table()
+
+    offset = 0
+    for bm_to_add in list_of_bmeshes:
 
         if bm_to_add.faces:
             for face in bm_to_add.faces:
                 nf = add_face([bm.verts[i.index + offset] for i in face.verts], face)
                 nf.copy_from(face)
-            bm.faces.index_update()
+        offset += len(bm_to_add.verts)
+    bm.faces.index_update()
 
     if normal_update:
         bm.normal_update()

--- a/utils/bmesh_utils.py
+++ b/utils/bmesh_utils.py
@@ -177,7 +177,6 @@ def bmesh_join(list_of_bmeshes: Iterable[bmesh.types.BMesh], normal_update=False
     bm = bmesh.new()
     add_vert = bm.verts.new
     add_face = bm.faces.new
-    add_edge = bm.edges.new
 
     copy_all_layers(list_of_bmeshes[0], bm)
 
@@ -193,20 +192,9 @@ def bmesh_join(list_of_bmeshes: Iterable[bmesh.types.BMesh], normal_update=False
 
         if bm_to_add.faces:
             for face in bm_to_add.faces:
-                nf = add_face(tuple(bm.verts[i.index + offset] for i in face.verts), face)
+                nf = add_face([bm.verts[i.index + offset] for i in face.verts], face)
                 nf.copy_from(face)
             bm.faces.index_update()
-
-        if bm_to_add.edges:
-            for edge in bm_to_add.edges:
-                edge_seq = tuple(bm.verts[i.index + offset] for i in edge.verts)
-                try:
-                    ne = add_edge(edge_seq, edge)
-                    ne.copy_from(edge)
-                except ValueError:
-                    # edge exists!
-                    pass
-            bm.edges.index_update()
 
     if normal_update:
         bm.normal_update()

--- a/utils/bmesh_utils.py
+++ b/utils/bmesh_utils.py
@@ -161,7 +161,7 @@ def bmesh_from_faces(src_bmesh: bmesh.types.BMesh, faces: Iterable[bmesh.types.B
 
     # Copy faces
     for face in faces:
-        dst_bmesh.faces.new(tuple(dst_bmesh.verts[v.index - min_vert_index] for v in face.verts), face)
+        dst_bmesh.faces.new([dst_bmesh.verts[v.index - min_vert_index] for v in face.verts], face)
     dst_bmesh.faces.index_update()
     dst_bmesh.faces.sort()
 

--- a/utils/utils.py
+++ b/utils/utils.py
@@ -157,6 +157,9 @@ def copy_multires_objs_to_new_mesh(context: bpy.types.Context, objects: Iterable
     final_bm.to_mesh(transpose_target_mesh)
     final_bm.free()
 
+    for bm in bms:
+        bm.free()
+
     # Reenable disabled modifiers
     for mod in disabled_modifiers:
         mod.show_viewport = True

--- a/utils/utils.py
+++ b/utils/utils.py
@@ -75,8 +75,8 @@ def create_meshes_by_original_name(object: bpy.types.Object) -> List[bpy.types.O
             transpose_map[name].append(face)
 
         for obj_name, faces in transpose_map.items():
-            face_index_min = min([f.index for f in faces])
-            face_index_max = max([f.index for f in faces])
+            face_index_min = min(faces, key=lambda f: f.index).index
+            face_index_max = max(faces, key=lambda f: f.index).index
 
             # Create a new bmesh from the faces associated with the original object
             d_bm = bmesh_from_faces(bm, bm.faces[face_index_min:face_index_max + 1])

--- a/utils/utils.py
+++ b/utils/utils.py
@@ -62,8 +62,9 @@ def create_meshes_by_original_name(object: bpy.types.Object) -> List[bpy.types.O
         List[bpy.types.Object]: List of split objects
     """
     split_objects = []
+    depsgraph = bpy.context.evaluated_depsgraph_get()
 
-    with bmesh_from_obj(object) as bm:
+    with bmesh_from_obj(depsgraph.objects[object.name]) as bm:
         original_obj_names = read_layer_data(bm, MeshDomain.FACES, MeshLayerType.STRING, ORIGINAL_OBJECT_NAME_LAYER, uniform=False)
         if not all(original_obj_names):
             raise ValueError("Object does not have original object names recorded on all faces, cannot split to transpose targets")
@@ -142,7 +143,6 @@ def copy_multires_objs_to_new_mesh(context: bpy.types.Context, objects: Iterable
         record_data_helper(bm, object, multires_levels[i])
         bms.append(bm)
         merged_objs.append(object)
-        print(i, object)
 
     if use_non_multires:
         non_multires_objects = [obj for obj in objects if obj not in multires_objs]
@@ -152,7 +152,6 @@ def copy_multires_objs_to_new_mesh(context: bpy.types.Context, objects: Iterable
             record_data_helper(bm, object, None)
             bms.append(bm)
             merged_objs.append(object)
-            print(object)
 
     final_bm = bmesh_join(bms)
     final_bm.to_mesh(transpose_target_mesh)

--- a/utils/utils.py
+++ b/utils/utils.py
@@ -22,7 +22,7 @@ def set_multires_to_nth_level(objects: Iterable[bpy.types.Object], n: int | None
     Returns:
         set[bpy.types.Object], list[int]: Objects that have had they multires level changed, and their subdivision level
     """
-    changed_objs = set()
+    changed_objs = []
     levels = []
     for obj in set(objects):
         if obj.type == "MESH":
@@ -30,7 +30,7 @@ def set_multires_to_nth_level(objects: Iterable[bpy.types.Object], n: int | None
                 if mod.type == "MULTIRES":
                     if n is not None:
                         mod.levels = n
-                    changed_objs.add(obj)
+                    changed_objs.append(obj)
                     levels.append(mod.levels)
                     break
     return changed_objs, levels
@@ -47,6 +47,7 @@ def restore_vertex_index(bm: bmesh.types.BMesh) -> None:
     for v, original_index in zip(bm.verts, original_vertex_indices):
         v.index = original_index
     bm.verts.sort()
+    bm.verts.ensure_lookup_table()
 
 
 def create_meshes_by_original_name(object: bpy.types.Object) -> List[bpy.types.Object]:
@@ -114,28 +115,34 @@ def copy_multires_objs_to_new_mesh(context: bpy.types.Context, objects: Iterable
         # Record the original vertex indices in the new object's vertex layer
         write_layer_data(bm, MeshDomain.VERTS, MeshLayerType.INT, ORIGINAL_VERTEX_INDEX_LAYER, [v.index for v in bm.verts])
 
-        # Record the original subidivision level in the new object's face layer, or -1 if multires_level is None
-        if multires_level is not None:
-            write_layer_data(bm, MeshDomain.FACES, MeshLayerType.INT, ORIGINAL_SUBDIVISION_LEVEL_LAYER, [multires_level for f in bm.faces])
-        else:
-            write_layer_data(bm, MeshDomain.FACES, MeshLayerType.INT, ORIGINAL_SUBDIVISION_LEVEL_LAYER, [-1 for f in bm.faces])
+        # Record the original subidivision level in the new object's vertex layer, or -1 if multires_level is None
+        write_layer_data(bm, MeshDomain.VERTS, MeshLayerType.INT, ORIGINAL_SUBDIVISION_LEVEL_LAYER, [(multires_level if multires_level is not None else -1) for _ in bm.verts])
 
     # Create new mesh and object, then link it
     transpose_target_mesh = bpy.data.meshes.new(name="Multires_Transpose_Target")
 
     multires_objs, multires_levels = set_multires_to_nth_level(objects, level)
+
+    disabled_modifiers = []
+    # Disable modifiers besides the multires modifier
+    for obj in multires_objs:
+        for mod in obj.modifiers:
+            if mod.type != "MULTIRES":
+                mod.show_viewport = False
+                disabled_modifiers.append(mod)
+
     depsgraph = context.evaluated_depsgraph_get()
 
-    final_bm = bmesh.new()
+    bms = []
     merged_objs = []
 
     for i, object in enumerate(multires_objs):
         bm = bmesh.new()
         bm.from_mesh(depsgraph.objects[object.name].data)
         record_data_helper(bm, object, multires_levels[i])
-        final_bm = bmesh_join([bm, final_bm])
-        bm.free()
+        bms.append(bm)
         merged_objs.append(object)
+        print(i, object)
 
     if use_non_multires:
         non_multires_objects = [obj for obj in objects if obj not in multires_objs]
@@ -143,12 +150,17 @@ def copy_multires_objs_to_new_mesh(context: bpy.types.Context, objects: Iterable
             bm = bmesh.new()
             bm.from_mesh(object.data)
             record_data_helper(bm, object, None)
-            final_bm = bmesh_join([bm, final_bm])
-            bm.free()
+            bms.append(bm)
             merged_objs.append(object)
+            print(object)
 
+    final_bm = bmesh_join(bms)
     final_bm.to_mesh(transpose_target_mesh)
     final_bm.free()
+
+    # Reenable disabled modifiers
+    for mod in disabled_modifiers:
+        mod.show_viewport = True
 
     transpose_target_obj = bpy.data.objects.new(name="Multires_Transpose_Target", object_data=transpose_target_mesh)
     context.collection.objects.link(transpose_target_obj)


### PR DESCRIPTION
Bug fixes
Optimize speed when creating transpose target and applying transpose target
Now use evaluated deps graph object when applying transpose target: This allows modifiers to be used on the transpose target
Now will only use the result of the multires modifier when creating transpose target (ignores other modifiers)